### PR TITLE
[1rqfxn4] arrow position inside featured products

### DIFF
--- a/src/partials/sections/featured-products.hbs
+++ b/src/partials/sections/featured-products.hbs
@@ -1,4 +1,4 @@
-{{#> sections/carousel-scroll id="featured-products" class="my-5 my-lg-7" header="Sand & Sky featured products" button="Shop all featured"}}
+{{#> sections/carousel-scroll id="featured-products" class="my-5 my-lg-7 featured-products-carousel" header="Sand & Sky featured products" button="Shop all featured"}}
 	{{> compounds/product-card class="carousel-item mb-0" color="ff6f8d" title="Hydration Boost Cream Moisturiser (2 lines)"}}
 	{{> compounds/product-card class="carousel-item mb-0" color="cc3195" }}
 	{{> compounds/product-card class="carousel-item mb-0" color="66b3df" badge="Best Seller" }}

--- a/src/scss/sections/_featured-products.scss
+++ b/src/scss/sections/_featured-products.scss
@@ -2,9 +2,5 @@
 	.carousel-control-prev,
 	.carousel-control-next {
 		top: 30%;
-
-		@include media-breakpoint-up(lg) {
-			top: 26%;
-		}
 	}
 }


### PR DESCRIPTION
missing class inside partials sections/featured-products, and remove media query desktop for arrow position to make it centered of image same size with mobile version.

ref ticket and design:
https://app.clickup.com/t/7ntzq7
https://xd.adobe.com/view/6ae7ced1-e082-45d9-a06d-37b61e1628dd-3fb4/screen/ca934afd-d215-4889-a018-d4185a35f8eb/