### PR TITLE
[1vd92cp] Visibility secondary image on product card

### DIFF
--- a/src/scss/compounds/_product-card.scss
+++ b/src/scss/compounds/_product-card.scss
@@ -67,9 +67,11 @@
 // secondary image
 .img--hover {
 	opacity: 0;
+	visibility: hidden;
 
 	a:hover & {
 		opacity: 1;
 		transition: opacity .2s;
+		visibility: visible;
 	}
 }


### PR DESCRIPTION
ref: https://app.clickup.com/t/1vd92cp
don't show secondary image of product card when load page